### PR TITLE
fix: project-current will return nil if there is no project

### DIFF
--- a/ancilla.el
+++ b/ancilla.el
@@ -358,7 +358,8 @@ Return a relative path when a project is detected."
                    ((fboundp 'ffip-project-root)
                     (ffip-project-root))
                    ((and (fboundp 'project-current)
-                         (fboundp 'project-root))
+                         (fboundp 'project-root)
+                         (project-current))
                     (project-root (project-current)))
                    (t 'no-project)))
             (local-file-name


### PR DESCRIPTION
Because this can return nil, we should check that it has a value before calling out to `project-root`.

Otherwise the `project-root` function will fail.
```
Debugger entered--Lisp error: (cl-no-applicable-method project-root nil)
  signal(cl-no-applicable-method (project-root nil))
```