### PR TITLE
fix: compare symbol rather than list

### DIFF
--- a/ancilla.el
+++ b/ancilla.el
@@ -219,7 +219,7 @@ call `ancilla-rewrite' otherwise."
                      (plist-get buffer-context :excursion)
                      (plist-get buffer-context :selection)))
 
-   ((eq mode '(ask))
+   ((eq mode 'ask)
     ;; ignore the message and switch to ancilla-chat. we should do
     ;; more than this in the future.
     (lambda (message)


### PR DESCRIPTION
`mode` will be a symbol, not a list so the `eq` comparison needs to be comparing a symbol to another symbol.